### PR TITLE
Fix problem on calling has_resource? multiple times

### DIFF
--- a/lib/chef-helpers/has_source.rb
+++ b/lib/chef-helpers/has_source.rb
@@ -17,7 +17,7 @@ module ChefHelpers
       cookbook ||= cookbook_name
       begin
         run_context.cookbook_collection[cookbook].
-          preferred_filename_on_disk_location(run_context.node, segment, source)
+          send(:find_preferred_manifest_record, run_context.node, segment, source)
       rescue Chef::Exceptions::FileNotFound
         nil
       end


### PR DESCRIPTION
Hi, I found that calling `has_resource?` multiples times returns different (and wrong) results.

Assume we have `files/foo.txt`, and run `recies/default.rb` whose contents are like:

``` ruby
puts has_cookbook_file?("bar.txt") #=> nil
puts has_cookbook_file?("foo.txt") #=> /path/to/cookbook/files/foo.txt
puts has_cookbook_file?("bar.txt") #=> nil
puts has_cookbook_file?("foo.txt") #=> nil!!!!
```

The 2nd time `has_cookbook_file?("foo.txt")` misses the existence of `files/foo.txt`. 

It seems the reason is because `Chef::CookbookVersion#preferred_manifest_record` does destructive operations when cookbook_file is not found (for "bar.txt") at 

``` ruby
          # Strip the root_dir prefix off all files for readability
          existing_files.map!{|path| path[root_dir.length+1..-1]} if root_dir
```

https://github.com/chef/chef/blob/9467b30cc1690f566f083d1710fd0436adb8b67b/lib/chef/cookbook_version.rb#L330

The contents of the `existing_files` variable were becoming as follows:

```
# before
existing_files #=> ["/path/to/cookbook/files/foo.txt"]
# after has_cookbook_file?("bar.txt")
existing_files #=> ["files/foo.txt"]
# after has_cookbook_file?("bar.txt") 2nd time
existing_files #=> [nil]
```

This patch avoids the problem by calling `find_preferred_manifest_record` instead of `preferred_manifest_record`. 
